### PR TITLE
INT-219: add version for backoff

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(
         'singer-python==5.7.0',
         'requests==2.21.0',
         'psutil==5.6.6',
-        'backoff'
+        'backoff==1.8.0'
     ],
     entry_points="""
     [console_scripts]

--- a/setup.py
+++ b/setup.py
@@ -12,8 +12,7 @@ setup(
     install_requires=[
         'singer-python==5.7.0',
         'requests==2.21.0',
-        'psutil==5.6.6',
-        'backoff==1.8.0'
+        'psutil==5.6.6'
     ],
     entry_points="""
     [console_scripts]


### PR DESCRIPTION
We currently don't specify a version for the backoff library which causes issues with singer-python which has its own specific dependency version for backoff. We can remove the line since singer-python takes care of the dependency requirement.